### PR TITLE
Add transform zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "homepage": "https://github.com/terrestris/d3-util#readme",
   "dependencies": {},
   "peerDependencies": {
-    "d3": "~5"
+    "d3": "~5",
+    "d3-tip": "0.9.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",
@@ -36,6 +37,7 @@
     "babel-preset-stage-0": "6.24.1",
     "coveralls": "3.0.2",
     "d3": "5.7.0",
+    "d3-tip": "0.9.1",
     "jest": "23.5.0",
     "moment": "2.22.2",
     "np": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@terrestris/d3-util",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A set of helper classes for working with d3 charts.",
   "main": "src/index.js",
   "scripts": {

--- a/src/ChartDataUtil/ChartDataUtil.js
+++ b/src/ChartDataUtil/ChartDataUtil.js
@@ -12,14 +12,21 @@ class ChartDataUtil {
   static lineDataFromPointData(data) {
     const lineData = [];
     let last;
+    let line = [];
     data.forEach(d => {
       if (d !== undefined && last !== undefined) {
-        lineData.push([last[0], last[1], d[0], d[1]]);
+        line.push(last);
       } else {
-        lineData.push(undefined);
+        if (line.length > 1) {
+          lineData.push(line);
+        }
+        line = [];
       }
       last = d;
     });
+    if (line.length > 1) {
+      lineData.push(line);
+    }
     return lineData;
   }
 

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -165,7 +165,7 @@ class TimeseriesComponent {
       .on('zoom', () => {
         const transform = event.transform;
         this.mainScaleX = transform.rescaleX(this.originalScaleX);
-        this.mainScaleY = transform.rescaleY(this.originalScaleY);
+        this.yScales = this.originalYScales.map(scale => transform.rescaleY(scale));
         if (this.config.zoomMode === 'transform') {
           root.selectAll('.x-axis').remove();
           root.selectAll('.y-axis').remove();
@@ -198,8 +198,8 @@ class TimeseriesComponent {
     const yScales = [];
     this.config.series.forEach((line, idx) => {
       let y = this.createScale(line.scaleY, size[1], line.data.filter(d => d).map(d => d[1]), true);
-      if (rerender && idx === 0) {
-        y = this.mainScaleY;
+      if (rerender) {
+        y = this.yScales[idx];
       }
       yScales.push(y);
       if (line.drawAxis) {
@@ -221,12 +221,12 @@ class TimeseriesComponent {
       this.renderLine(lineg, line, idx, x, y);
     });
     this.drawXAxis(x, g, size, width);
-    this.mainScaleY = yScales[0];
+    this.yScales = yScales;
     this.mainScaleX = x;
     if (!rerender) {
       this.enableZoom(root, size);
       this.originalScaleX = x;
-      this.originalScaleY = yScales[0];
+      this.originalYScales = yScales;
     }
   }
 

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -134,7 +134,7 @@ class TimeseriesComponent {
    * @param  {selection} selection the d3 selection to append the axes to
    * @param  {number[]} size the chart size
    */
-  drawYAxis(y, series, selection) {
+  drawYAxis(y, series, selection, size) {
     const yAxis = AxesUtil.createYAxis(series.scaleY, y);
 
     const prevAxes = selection.selectAll('.y-axis').nodes();
@@ -147,7 +147,7 @@ class TimeseriesComponent {
     if (series.yAxisLabel) {
       axis.append('text')
         .attr('transform', 'rotate(-90)')
-        .attr('x', -300)
+        .attr('x', -size[1] / 2)
         .attr('y', -20)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -151,7 +151,7 @@ class TimeseriesComponent {
         .attr('y', -20)
         .attr('dy', '1em')
         .style('text-anchor', 'middle')
-        .style('fill', 'black')
+        .style('fill', series.color)
         .text(series.yAxisLabel);
     }
   }

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -166,6 +166,12 @@ class TimeseriesComponent {
         const transform = event.transform;
         this.mainScaleX = transform.rescaleX(this.originalScaleX);
         this.mainScaleY = transform.rescaleY(this.originalScaleY);
+        if (this.config.zoomMode === 'transform') {
+          root.selectAll('.x-axis').remove();
+          root.selectAll('.y-axis').remove();
+          root.selectAll('circle,line')
+            .attr('transform', transform);
+        }
         this.render(root, size, true);
       });
     root.append('rect')
@@ -185,7 +191,7 @@ class TimeseriesComponent {
    * @param  {boolean} rerender if true, rerendering mode is enabled
    */
   render(root, size, rerender) {
-    if (rerender) {
+    if (rerender && this.config.zoomMode !== 'transform') {
       root.selectAll('g.timeseries').remove();
     }
     const g = root.append('g').attr('class', 'timeseries');
@@ -205,6 +211,9 @@ class TimeseriesComponent {
     const xData = this.config.series.reduce((acc, line) => acc.concat(line.data.filter(d => d).map(d => d[0])), []);
     const x = rerender ? this.mainScaleX : this.createScale(this.config.scaleX, size[0] - width, xData, false);
     this.config.series.forEach((line, idx) => {
+      if (rerender && this.config.zoomMode === 'transform') {
+        return;
+      }
       const y = yScales[idx];
       const dotsg = g.append('g').attr('transform', `translate(${width}, 0)`);
       const lineg = g.append('g').attr('transform', `translate(${width}, 0)`);

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -5,6 +5,7 @@ import scaleLinear from 'd3-scale/src/linear';
 import scaleTime from 'd3-scale/src/time';
 import zoom from 'd3-zoom/src/zoom';
 import {event} from 'd3-selection/src/selection/on';
+import d3line from 'd3-shape/src/line.js';
 
 /**
  * A component that can be used in the chart renderer to render a timeseries
@@ -85,18 +86,18 @@ class TimeseriesComponent {
    */
   renderLine(g, line, idx, x, y) {
     const lineData = ChartDataUtil.lineDataFromPointData(line.data);
+    lineData.forEach(data => {
+      const generator = d3line()
+        .x(d => x(d[0]))
+        .y(d => y(d[1]));
 
-    g.selectAll(`line.series-${idx}`)
-      .data(lineData)
-      .enter()
-      .filter(d => d)
-      .append('line')
-      .attr('class', `series-${idx}`)
-      .attr('x1', d => x(d[0]))
-      .attr('y1', d => y(d[1]))
-      .attr('x2', d => x(d[2]))
-      .attr('y2', d => y(d[3]))
-      .style('stroke', line.color);
+      g.append('path')
+        .datum(data)
+        .attr('d', generator)
+        .attr('class', `series-${idx}`)
+        .style('fill', 'none')
+        .style('stroke', line.color);
+    });
   }
 
   /**

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -170,7 +170,7 @@ class TimeseriesComponent {
         if (this.config.zoomMode === 'transform') {
           root.selectAll('.x-axis').remove();
           root.selectAll('.y-axis').remove();
-          root.selectAll('circle,line')
+          root.selectAll('circle,path')
             .attr('transform', transform);
         }
         this.render(root, size, true);

--- a/src/TimeseriesComponent/TimeseriesComponent.js
+++ b/src/TimeseriesComponent/TimeseriesComponent.js
@@ -6,6 +6,7 @@ import scaleTime from 'd3-scale/src/time';
 import zoom from 'd3-zoom/src/zoom';
 import {event} from 'd3-selection/src/selection/on';
 import d3line from 'd3-shape/src/line.js';
+import d3tip from 'd3-tip';
 
 /**
  * A component that can be used in the chart renderer to render a timeseries
@@ -64,6 +65,10 @@ class TimeseriesComponent {
    * @param  {d3.scale} y the y scale
    */
   renderDots(g, line, idx, x, y) {
+    const tip = d3tip().attr('class', 'd3-tip').html(d => d[1]);
+
+    g.call(tip);
+
     g.selectAll(`circle.series-${idx}`)
       .data(line.data)
       .enter()
@@ -73,7 +78,9 @@ class TimeseriesComponent {
       .attr('cx', d => x(d[0]))
       .attr('cy', d => y(d[1]))
       .attr('r', '5px')
-      .attr('fill', line.color);
+      .attr('fill', line.color)
+      .on('mouseover', tip.show)
+      .on('mouseout', tip.hide);
   }
 
   /**
@@ -133,10 +140,20 @@ class TimeseriesComponent {
     const prevAxes = selection.selectAll('.y-axis').nodes();
     const width = prevAxes.reduce((acc, node) => acc + node.getBBox().width, 0) + 5 * prevAxes.length;
 
-    selection.append('g')
+    const axis = selection.append('g')
       .attr('class', 'y-axis')
       .attr('transform', `translate(${width}, 0)`)
       .call(yAxis);
+    if (series.yAxisLabel) {
+      axis.append('text')
+        .attr('transform', 'rotate(-90)')
+        .attr('x', -300)
+        .attr('y', -20)
+        .attr('dy', '1em')
+        .style('text-anchor', 'middle')
+        .style('fill', 'black')
+        .text(series.yAxisLabel);
+    }
   }
 
   /**
@@ -175,14 +192,7 @@ class TimeseriesComponent {
         }
         this.render(root, size, true);
       });
-    root.append('rect')
-      .attr('x', 0)
-      .attr('y', 0)
-      .attr('width', size[0])
-      .attr('height', size[1])
-      .style('fill', 'none')
-      .style('pointer-events', 'all')
-      .call(this.zoomBehaviour);
+    root.call(this.zoomBehaviour);
   }
 
   /**


### PR DESCRIPTION
Adds a new `zoomMode` config option for timeseries that alters zooming to use svg transform when set to that value. This is faster, but is closer to a real image zoom (dots and lines get bigger).

Also enables/fixes the zoom for multiple series/yaxes.

Also improves performance drastically by switching from `line` to `path` elements.

@terrestris/devs Please review.