### PR TITLE
Use external moment.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A set of helper classes for working with d3 charts.
 npm i @terrestris/d3-util
 ```
 
+In order to use the library in your project, make sure you load
+[the moment.js library](https://momentjs.com/) as well.
+
 ## Usage
 
 ### General notes

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,5 +37,8 @@ module.exports = {
   },
   output: {
     library: 'D3Util'
+  },
+  externals: {
+    moment: 'moment'
   }
 };


### PR DESCRIPTION
Externalizes the moment.js library excluding it from the build. This reduces prod build size from 354kb to 130kb.

@terrestris/devs Please review.