### PR TITLE
Adds possibility to configure a locale in axis config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     'node_modules'
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(d3|d3-selection|d3-array|d3-scale|d3-zoom|d3-shape|d3-color)/)'
+    'node_modules/(?!(d3|d3-selection|d3-array|d3-scale|d3-zoom|d3-shape|d3-color|d3-time-format)/)'
   ],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
     'node_modules'
   ],
   transformIgnorePatterns: [
-    'node_modules/(?!(d3|d3-selection|d3-array|d3-scale|d3-zoom|d3-shape|d3-color|d3-time-format)/)'
+    'node_modules/(?!(d3|d3-selection|d3-array|d3-scale|d3-zoom|d3-shape|d3-color|d3-time-format|d3-format)/)'
   ],
   collectCoverage: true,
   collectCoverageFrom: [

--- a/src/AxesUtil/AxesUtil.js
+++ b/src/AxesUtil/AxesUtil.js
@@ -64,12 +64,12 @@ class AxesUtil {
    * @return {Boolean} the d3 axis object
    */
   static createAxis(config, scale, axisFunc) {
-    const locale = config.locale || 'en';
-    const format = formatLocale(locale.startsWith('de') ? FormatdeDE : FormatenUS).format;
     // return early if no config is present
     if (!config) {
       return;
     }
+    const locale = config.locale || 'en';
+    const format = formatLocale(locale.startsWith('de') ? FormatdeDE : FormatenUS).format;
     let tickFormatter;
     if (config.scale === 'time') {
       tickFormatter = this.getMultiScaleTimeFormatter(config.locale || 'en');

--- a/src/AxesUtil/AxesUtil.js
+++ b/src/AxesUtil/AxesUtil.js
@@ -1,8 +1,6 @@
 import LabelUtil from '../LabelUtil/LabelUtil';
 import moment from 'moment';
-import {
-  timeFormat
-} from 'd3-time-format';
+import timeFormatLocale from 'd3-time-format/src/locale.js';
 import {
   timeSecond,
   timeMinute,
@@ -13,8 +11,12 @@ import {
   timeYear
 } from 'd3-time';
 import {axisBottom, axisLeft} from 'd3-axis';
-import {format} from 'd3-format';
+import formatLocale from 'd3-format/src/locale.js';
 import select from 'd3-selection/src/select';
+import deDE from 'd3-time-format/locale/de-DE.json';
+import enUS from 'd3-time-format/locale/en-US.json';
+import FormatdeDE from 'd3-format/locale/de-DE.json';
+import FormatenUS from 'd3-format/locale/en-US.json';
 
 /**
  * Class with helper functions to create/manage chart axes.
@@ -28,28 +30,30 @@ class AxesUtil {
    * See https://github.com/d3/d3-time-format/blob/master/README.md#locale_format
    * for available D3 datetime formats.
    *
-   * @param  {Date} date The current Date object.
+   * @param  {string} locale The desired locale (de or en currently)
    * @return {function} The multi-scale time format function.
    */
-  static getMultiScaleTimeFormatter(date) {
-    date = moment(date);
+  static getMultiScaleTimeFormatter(locale) {
+    return date => {
+      date = moment(date);
+      const loc = locale.startsWith('de') ? timeFormatLocale(deDE) : timeFormatLocale(enUS);
+      const formatMillisecond = loc.format('.%L');
+      const formatSecond = loc.format(':%S');
+      const formatMinute = loc.format('%H:%M');
+      const formatHour = loc.format('%H:%M');
+      const formatDay = loc.format('%a %d');
+      const formatWeek = loc.format('%b %d');
+      const formatMonth = loc.format('%B');
+      const formatYear = loc.format('%Y');
 
-    const formatMillisecond = timeFormat('.%L');
-    const formatSecond = timeFormat(':%S');
-    const formatMinute = timeFormat('%H:%M');
-    const formatHour = timeFormat('%H:%M');
-    const formatDay = timeFormat('%a %d');
-    const formatWeek = timeFormat('%b %d');
-    const formatMonth = timeFormat('%B');
-    const formatYear = timeFormat('%Y');
-
-    return (timeSecond(date) < date ? formatMillisecond
-      : timeMinute(date) < date ? formatSecond
-        : timeHour(date) < date ? formatMinute
-          : timeDay(date) < date ? formatHour
-            : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
-              : timeYear(date) < date ? formatMonth
-                : formatYear)(date);
+      return (timeSecond(date) < date ? formatMillisecond
+        : timeMinute(date) < date ? formatSecond
+          : timeHour(date) < date ? formatMinute
+            : timeDay(date) < date ? formatHour
+              : timeMonth(date) < date ? (timeWeek(date) < date ? formatDay : formatWeek)
+                : timeYear(date) < date ? formatMonth
+                  : formatYear)(date);
+    };
   }
 
   /**
@@ -60,13 +64,15 @@ class AxesUtil {
    * @return {Boolean} the d3 axis object
    */
   static createAxis(config, scale, axisFunc) {
+    const locale = config.locale || 'en';
+    const format = formatLocale(locale.startsWith('de') ? FormatdeDE : FormatenUS).format;
     // return early if no config is present
     if (!config) {
       return;
     }
     let tickFormatter;
     if (config.scale === 'time') {
-      tickFormatter = this.getMultiScaleTimeFormatter;
+      tickFormatter = this.getMultiScaleTimeFormatter(config.locale || 'en');
     } else if (config.scale === 'band') {
       // a numeric format makes no sense here
       tickFormatter = s => s;

--- a/src/AxesUtil/AxesUtil.spec.js
+++ b/src/AxesUtil/AxesUtil.spec.js
@@ -13,48 +13,58 @@ describe('AxesUtil', () => {
   });
 
   it('returns a string when formatting time', () => {
-    const fn = AxesUtil.getMultiScaleTimeFormatter();
+    const fn = AxesUtil.getMultiScaleTimeFormatter('en')();
     expect((typeof fn) === 'string').toEqual(true);
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-31T13:26:59.889');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('.889');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('.889');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-31T13:26:59.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual(':59');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual(':59');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-31T13:26:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('13:26');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('13:26');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-31T00:00:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('Wed 31');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('Wed 31');
+  });
+
+  it('returns the appropriate formatted time', () => {
+    const date = moment('2018-10-31T00:00:00.000');
+    expect(AxesUtil.getMultiScaleTimeFormatter('de')(date)).toEqual('Mi 31');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-01T00:00:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('October');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('October');
+  });
+
+  it('returns the appropriate formatted time', () => {
+    const date = moment('2018-10-01T00:00:00.000');
+    expect(AxesUtil.getMultiScaleTimeFormatter('de')(date)).toEqual('Oktober');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-01-01T00:00:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('2018');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('2018');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-20T01:00:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('01:00');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('01:00');
   });
 
   it('returns the appropriate formatted time', () => {
     const date = moment('2018-10-21T00:00:00.000');
-    expect(AxesUtil.getMultiScaleTimeFormatter(date)).toEqual('Oct 21');
+    expect(AxesUtil.getMultiScaleTimeFormatter('en')(date)).toEqual('Oct 21');
   });
 
   it('can create d3 axis objects', () => {


### PR DESCRIPTION
This makes the axis formatter use the i10n formatters from d3. For now
the locale config is just a two letter code in the axis config, but
could be improved to be the d3 i10n locale configs in order to avoid
preloading the locale definitions.

@terrestris/devs Please review.