### PR TITLE
Correct misspelled constant

### DIFF
--- a/src/ScaleUtil/ScaleUtil.ts
+++ b/src/ScaleUtil/ScaleUtil.ts
@@ -43,7 +43,7 @@ class ScaleUtil {
     data: any[],
     reverse: boolean
   ) {
-    const epsilion = axis.epsilon || ScaleUtil.EPSILON;
+    const epsilon = axis.epsilon || ScaleUtil.EPSILON;
     let axisDomain;
     let makeDomainNice = true;
     let min;
@@ -80,13 +80,13 @@ class ScaleUtil {
       axisDomain[1] = Math.pow(10, Math.ceil(Math.log(axisDomain[1]) / Math.log(10)));
     }
 
-    if (axis.scale === 'log' && (axisDomain[0] < epsilion || axisDomain[1] < epsilion ||
+    if (axis.scale === 'log' && (axisDomain[0] < epsilon || axisDomain[1] < epsilon ||
       isNaN(axisDomain[0]) || isNaN(axisDomain[1]))) {
-      if (axisDomain[0] < epsilion || isNaN(axisDomain[0])) {
-        axisDomain[0] = epsilion;
+      if (axisDomain[0] < epsilon || isNaN(axisDomain[0])) {
+        axisDomain[0] = epsilon;
       }
-      if (axisDomain[1] < epsilion || isNaN(axisDomain[1])) {
-        axisDomain[1] = epsilion;
+      if (axisDomain[1] < epsilon || isNaN(axisDomain[1])) {
+        axisDomain[1] = epsilon;
       }
     }
 


### PR DESCRIPTION
A trivial change. Fixes the typo mentioned [in this comment](https://github.com/terrestris/d3-util/pull/107#discussion_r292970275).

Please review.