### PR TITLE
Add area plots, export d3, add x-axis label

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The chart renderer can be constructed with a few parameters:
   `'rerender'` for a zoom rebuilding the DOM. Using the transform method has the
   effect of also zooming the shapes, i.e. a line of 1px will get bigger when
   zooming in.
+* `eventFn`: the function that will be called on every mouse move over the
+  entire `svg`.
 
 ### Components
 

--- a/src/ChartRenderer/ChartRenderer.ts
+++ b/src/ChartRenderer/ChartRenderer.ts
@@ -14,6 +14,7 @@ export interface ChartConfiguration {
   components: ChartComponent[];
   zoomType?: ZoomType;
   dynamicSize?: boolean;
+  eventFn?: () => {};
 }
 
 /**
@@ -59,7 +60,8 @@ export class ChartRenderer {
       components,
       size,
       zoomType,
-      dynamicSize
+      dynamicSize,
+      eventFn
     } = this.chartConfig;
 
     select(element).selectAll('svg').remove();
@@ -72,6 +74,13 @@ export class ChartRenderer {
         component.enableZoom(svg, zoomType);
       }
     });
+
+    if (eventFn) {
+      svg
+      .on('mousemove', function() {
+        eventFn();
+      });
+    }
 
     if (dynamicSize) {
       // this currently only works properly for legend heights

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import ScaleUtil from './ScaleUtil/ScaleUtil';
 import TimeseriesComponent from './TimeseriesComponent/TimeseriesComponent';
 import BarComponent from './BarComponent/BarComponent';
 import LegendComponent from './LegendComponent/LegendComponent';
+import * as d3 from 'd3';
 
 export {
   ChartDataUtil,
@@ -11,5 +12,6 @@ export {
   ScaleUtil,
   TimeseriesComponent,
   BarComponent,
-  LegendComponent
+  LegendComponent,
+  d3
 };


### PR DESCRIPTION
This

* adds area plots for timeseries components
* exports the `d3` object under `D3Util.d3`
* adds labeling of the x-axis
* adds configurable event listener to the whole svg object