### PR TITLE
TimeseriesChart add mouseOut tooltip function

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ A line chart configuration has the following options:
 * `curveType`: a d3 curve type string like `curveStepBefore`
 * `shapeType`: usually `'line'`, can also be `'area'`
 * `useTooltipFunc`: a boolean indicating whether the third data value is a
-  tooltip function
-* `data`: an array with the data: `[xvalue, yvalue, tooltipFunc, styleObject]`
+  tooltip mouseover function and fifth value is a mouseout function
+* `data`: an array with the data: `[xvalue, yvalue, mouseOverFunc, styleObject, mouseOutFunc]`
 * `initiallyVisible`: a boolean indicating whether the line is initially visible
   defaulting to true
 

--- a/src/TimeseriesComponent/TimeseriesComponent.ts
+++ b/src/TimeseriesComponent/TimeseriesComponent.ts
@@ -132,7 +132,9 @@ class TimeseriesComponent implements ChartComponent {
         d[2](dots[index]);
       };
       out = (d: any[], index: number, dots: any) => {
-        d[4](dots[index]);
+        if (d[4]) {
+          d[4](dots[index]);
+        }
       };
     }
 

--- a/src/TimeseriesComponent/TimeseriesComponent.ts
+++ b/src/TimeseriesComponent/TimeseriesComponent.ts
@@ -119,7 +119,7 @@ class TimeseriesComponent implements ChartComponent {
     /** Empty fn. */
     let over = (...args: any): any => undefined;
     /** Empty fn. */
-    let out = (): any => undefined;
+    let out = (...args: any): any => undefined;
 
     if (line.showTooltip) {
       const tip: any = d3tip().attr('class', 'd3-tip').html(d => d[1]);
@@ -130,6 +130,9 @@ class TimeseriesComponent implements ChartComponent {
     if (line.useTooltipFunc) {
       over = (d: any[], index: number, dots: any) => {
         d[2](dots[index]);
+      };
+      out = (d: any[], index: number, dots: any) => {
+        d[4](dots[index]);
       };
     }
 


### PR DESCRIPTION
**Feature**  
- enables optional mouseOut function to data array in `TimeseriesComponent` for a better manual tooltip handling (no error, if not defined)

**Background:**  
- `d3-tip` which could be used for tooltips is no longer maintained and not working with recent d3 version
- remove and maybe replacement of `d3-tip` must be discussed on follow-up PR

please note: @hwbllmnn 